### PR TITLE
feat: expose the filter_internal_priming flag to the command line interface

### DIFF
--- a/lapa/lapa.py
+++ b/lapa/lapa.py
@@ -434,7 +434,7 @@ def lapa(alignment: str, fasta: str, annotation: str, chrom_sizes :str, output_d
          cluster_extent_cutoff=3, cluster_window=25, cluster_ratio_cutoff=0.05,
          min_replication_rate=0.95, replication_rolling_size=1000,
          replication_num_sample=2, replication_min_count=1,
-         non_replicates_read_threhold=10):
+         non_replicates_read_threhold=10, filter_internal_priming=True):
     '''
     LAPA high level api for polyA cluster calling.
 
@@ -484,6 +484,7 @@ def lapa(alignment: str, fasta: str, annotation: str, chrom_sizes :str, output_d
       replication_min_count: Minimum count needed to recognize region as expressed
       non_replicates_read_threhold: Minimum read count need for the samples without replication.
         If there is not replicate samples for the sample, this default cutoff will be applied.
+      filter_internal_priming:  Whether to filter peaks for internal priming artefacts based on genomic A content immediately downstream of representative position (> 7 / 10 As & no polyA signal sequence found (-60 PAS +10)).     
     '''
     _lapa = Lapa(fasta, annotation, chrom_sizes, output_dir, method=method,
                  min_tail_len=min_tail_len, min_percent_a=min_percent_a, mapq=mapq,
@@ -493,7 +494,8 @@ def lapa(alignment: str, fasta: str, annotation: str, chrom_sizes :str, output_d
                  replication_rolling_size=replication_rolling_size,
                  replication_num_sample=replication_num_sample,
                  replication_min_count=replication_min_count,
-                 non_replicates_read_threhold=non_replicates_read_threhold)
+                 non_replicates_read_threhold=non_replicates_read_threhold,
+                 filter_internal_priming=filter_internal_priming)
     _lapa(alignment)
 
 

--- a/lapa/main.py
+++ b/lapa/main.py
@@ -100,15 +100,27 @@ from lapa.correction import correct_talon
               ' this default cutoff will be applied.',
               default=10,
               type=int)
+@click.option('--disable_internal_priming_filter',
+              help='Disable internal priming filter for putative PAS clusters.'
+              " Not recommended unless the library preparation protocol is expected to avoid internal priming artefacts (e.g. Nanopore direct RNA sequencing, 3'READS).",
+              is_flag=True)
+
+
 def cli_lapa(alignment, fasta, annotation, chrom_sizes, output_dir,
              counting_method, min_tail_len=10, min_percent_a=0.9, mapq=10,
              cluster_extent_cutoff=3, cluster_ratio_cutoff=0.05, cluster_window=25,
              min_replication_rate=0.95, replication_rolling_size=1000,
              replication_num_sample=2, replication_min_count=1,
-             non_replicates_read_threhold=10):
+             non_replicates_read_threhold=10, disable_internal_priming_filter=False):
     '''
     CLI interface for lapa polyA cluster calling.
     '''
+
+    if disable_internal_priming_filter:
+        filter_internal_priming = False
+    else:
+        filter_internal_priming = True
+    
     lapa(alignment, fasta, annotation, chrom_sizes, output_dir,
          counting_method, min_tail_len=min_tail_len,
          min_percent_a=min_percent_a,
@@ -119,7 +131,8 @@ def cli_lapa(alignment, fasta, annotation, chrom_sizes, output_dir,
          replication_rolling_size=replication_rolling_size,
          replication_num_sample=replication_num_sample,
          replication_min_count=replication_min_count,
-         non_replicates_read_threhold=non_replicates_read_threhold)
+         non_replicates_read_threhold=non_replicates_read_threhold,
+         filter_internal_priming=filter_internal_priming)
 
 
 @click.command()

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ test_requirements = ['pytest']
 
 setup(
     name='lapa',
-    version='0.0.6',
+    version='0.0.7',
 
     author=" ".join(["M. Hasan Çelik", "Sam Bryce-Smith"]),
     author_email='muhammedhasancelik@gmail.com',


### PR DESCRIPTION
Add an optional command line flag to disable the internal priming filtering applied to putative PAS clusters (>7 / 10 downstream nts as As & no polyA signal -60 to +10 nt of the PAS). Default behaviour is unchanged (i.e. filtering is performed by default). Only intended to be used for protocols where internal priming is not anticipated (e.g. due to use of adapter ligation instead of oligo-dT priming in nanopore direct RNA sequencing). See below snippet for testing the correct switching on of the flag.


```bash
$ conda activate lapa_dev
# Run equivalent command line call to 'test_lapa_bam_quantseq' from tests/test_lapa.py with flag enabled and disabled
$ lapa --alignment tests/data/quantseq3_gm12878_chr17_rep1.bam,tests/data/quantseq3_gm12878_chr17_rep2.bam --fasta tests/data/chr17.fa --annotation tests/data/_chr17.gtf --chrom_sizes tests/data/chrom_sizes --output_dir test_disableip_noflag
$ lapa --alignment tests/data/quantseq3_gm12878_chr17_rep1.bam,tests/data/quantseq3_gm12878_chr17_rep2.bam --fasta tests/data/chr17.fa --annotation tests/data/_chr17.gtf --chrom_sizes tests/data/chrom_sizes --output_dir test_disableip_flag --disable_internal_priming_filter
# run with flag enabled - expected output is 0
$ awk -F"\t" '{if ($12 > 7 && $13 == "None@None") {print $0}}' test_disableip_noflag/polyA_clusters.bed | wc -l
0
# run with flag disabled - expected output is non-zero
$ awk -F"\t" '{if ($12 > 7 && $13 == "None@None") {print $0}}' test_disableip_flag/polyA_clusters.bed | wc -l
124
```