### PR TITLE
Add Dockerfile for running lapa via the CLI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,39 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+.venv/
+
+# git & github
+.git/
+.gitignore
+.github/
+
+# LAPA-specific
+configs/
+docs/
+notebooks/
+reports/
+slurm/
+workflow/
+lapa/__pycache__/
+.readthedocs.yaml
+env*.yaml
+environment.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Alternative: Start with Python 3.7 and install uv
+# use full version instead of slim to ensure gcc compiler installed (bamread dependency)
+FROM python:3.7.17-bookworm
+
+# Copy uv binary from official image (pinned to specific version for reproducibility)
+COPY --from=ghcr.io/astral-sh/uv:0.7.17 /uv /uvx /bin/
+
+# Set environment variables for uv
+ENV UV_SYSTEM_PYTHON=1
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+
+# Set working directory
+WORKDIR /app
+
+# Copy minimal package files
+COPY README.md setup.py /app/
+COPY lapa/ /app/lapa/
+
+# Install the package using uv with cache mount (+ certain dependencies first to avoid uv resolving max compatible version and returning errors)
+# Install pyranges 0.0.120 to avoid "pandas.errors.IntCastingNaNError: Cannot convert non-finite values (NA or inf) to integer" error with 
+# suspect introduced in 0.0.121 (https://github.com/pyranges/pyranges/blob/c981927c7721073e96ceb85192ceafd36173d4a8/CHANGELOG.txt#L53)
+# https://github.com/mortazavilab/lapa/issues/30
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system "pyrle<0.0.41" "pyranges==0.0.120" && \
+    uv pip install --system .
+
+# Verify installation
+RUN lapa --help
+
+# Default command
+CMD ["lapa", "--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Alternative: Start with Python 3.7 and install uv
 # use full version instead of slim to ensure gcc compiler installed (bamread dependency)
-FROM python:3.7.17-bookworm
+FROM python:3.7.17-bookworm as builder
 
 # Copy uv binary from official image (pinned to specific version for reproducibility)
 COPY --from=ghcr.io/astral-sh/uv:0.7.17 /uv /uvx /bin/
@@ -24,6 +24,11 @@ COPY lapa/ /app/lapa/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system "pyrle<0.0.41" "pyranges==0.0.120" && \
     uv pip install --system .
+
+# Use a barebones python image for actually running the command line tools
+FROM python:3.7.17-slim-bookworm
+COPY --from=builder /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Verify installation
 RUN lapa --help


### PR DESCRIPTION
Adds a functional dockerfile recipe, now available on the [github container registry for 0.0.7](https://github.com/SamBryce-Smith/lapa/pkgs/container/lapa).

Uses `uv pip` for installation inside the dockerfile. I found that need to further restrict the pyrle and pyranges versions to ensure compatiblility with python 3.7 and to avoid an open bug on lapa https://github.com/mortazavilab/lapa/issues/30
- pyrle - 0.0.41 uses importlib which is python 3.8+ -https://github.com/pyranges/pyrle/blob/84c4877603ff299d56c8d218ef9f1b28559f7e48/CHANGELOG.txt#L1
- pyranges - [0.0.121 updates the numpy types](https://github.com/pyranges/pyranges/blob/c981927c7721073e96ceb85192ceafd36173d4a8/CHANGELOG.txt#L53). In local testing I reproduced [issue 30](https://github.com/mortazavilab/lapa/issues/30), which I resolved by simply dropping down to 0.0.120

TODO: update the version ranges in setup.py. It could be useful to add an explicit dependency for pyrle