### PR TITLE
fix: propagate non_replicates_read_threhold to _Lapa base class

### DIFF
--- a/lapa/lapa.py
+++ b/lapa/lapa.py
@@ -197,8 +197,8 @@ class _Lapa:
             if len(samples) == 1:
                 sample = samples[0]
                 self.warn_log.warning(
-                    f'Appling non_replicates_read_threhold={self.non_replicates_read_threhold}'
-                    ' to filter sample {sample} because sample does not replicates')
+                    f'Applying non_replicates_read_threhold={self.non_replicates_read_threhold}'
+                    f' to filter sample {sample} because sample does not replicate')
                 df_cluster = rep_samples[sample]
                 rep_samples = {
                     sample: df_cluster[df_cluster['count'] >= self.non_replicates_read_threhold]
@@ -354,7 +354,8 @@ class Lapa(_Lapa):
                          cluster_extent_cutoff, cluster_window,
                          cluster_ratio_cutoff,
                          min_replication_rate, replication_rolling_size,
-                         replication_num_sample, replication_min_count)
+                         replication_num_sample, replication_min_count,
+                         non_replicates_read_threhold)
 
         self.min_tail_len = min_tail_len
         self.min_percent_a = min_percent_a
@@ -410,7 +411,8 @@ class LapaTss(_Lapa):
                          cluster_extent_cutoff, cluster_window,
                          cluster_ratio_cutoff,
                          min_replication_rate, replication_rolling_size,
-                         replication_num_sample, replication_min_count)
+                         replication_num_sample, replication_min_count,
+                         non_replicates_read_threhold)
 
         self.prefix = 'tss'
         self.cluster_col_order = tss_cluster_col_order

--- a/tests/test_lapa.py
+++ b/tests/test_lapa.py
@@ -194,6 +194,35 @@ def test_lapa_bam_pb(tmp_path):
     assert df_cluster.shape == df_apa.shape
 
 
+def test_lapa_bam_pb_non_replicates_threshold(tmp_path):
+    """Test that a custom non_replicates_read_threhold is correctly propagated
+    through to the filtering logic and recorded in warnings.log."""
+    import re
+
+    output_dir = tmp_path / 'lapa'
+    non_replicates_read_threhold = 5
+
+    lapa(quantseq_gm12_bam, fasta, gtf, chrom_sizes, output_dir, method='tail',
+         non_replicates_read_threhold=non_replicates_read_threhold)
+
+    warnings_log = output_dir / 'logs' / 'warnings.log'
+    assert warnings_log.exists(), "warnings.log not found"
+
+    log_text = warnings_log.read_text()
+    match = re.search(r'non_replicates_read_threhold=(\d+)', log_text)
+    assert match is not None, \
+        "non_replicates_read_threhold not found in warnings.log"
+    logged_threshold = int(match.group(1))
+    assert logged_threshold == non_replicates_read_threhold, (
+        f"Expected non_replicates_read_threhold={non_replicates_read_threhold} "
+        f"in warnings.log but got {logged_threshold}"
+    )
+
+    df_apa = read_polyA_cluster(
+        str(output_dir / 'sample' / 'quantseq3_gm12878_chr17_rep1.bed'))
+    assert df_apa['count'].min() >= non_replicates_read_threhold
+
+
 def test_lapa_bam_quantseq(tmp_path):
 
     output_dir = tmp_path / 'lapa'


### PR DESCRIPTION
Both Lapa.__init__ and LapaTss.__init__ accepted non_replicates_read_threhold as a parameter but omitted it from their super().__init__() calls. This caused _Lapa to always fall back to its default value of 10, ignoring any user-supplied CLI value (--non_replicates_read_threhold).

Also fix a secondary bug in filter_replication(): the second half of the warning message was a plain string (not an f-string), so {sample} was printed literally rather than being interpolated. Fix the typo "Appling" -> "Applying" while here.

Add test_lapa_bam_pb_non_replicates_threshold to tests/test_lapa.py to verify that a custom threshold (5) is correctly propagated to warnings.log and applied to the output cluster count filter.

https://claude.ai/code/session_01ESDTzEBRs8hNURme3L7D6d